### PR TITLE
Fix XML snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ virsh edit win10
     <qemu:arg value="-audiodev"/>
     <qemu:arg value="pa,id=hda,server=/run/user/1000/pulse/native"/>
   </qemu:commandline>
-</devices>
+</domain>
 ```
 
 </td>


### PR DESCRIPTION
Thank you for providing this helpful guide. 
During my setup I think I noticed a small error in one of the libvirt XML snippets:

The `<qemu:commandline>` XML element should not be within the `<devices>` element.
I changed the `</devices>` tag to a `</domain>` tag like in the second XML snippet.